### PR TITLE
2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wikimedia/resource-modules",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "",
   "main": "dist/cli.js",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,10 +16,11 @@ const RESOURCES = "/resources";
 const frontendAssets = RESOURCES;
 const coreResources = `${RESOURCES}/Resources.php`;
 
-if (process.argv.length >= 3) {
-  const extensionPath = path.resolve(process.argv[2]);
+const args = process.argv;
+if (args.length === 3 || args.length === 4) {
+  const extensionPath = path.resolve(args[2]);
   const corePath = path.resolve(path.join(extensionPath, "../.."));
-  const jsonFilename = process.argv[3] || "extension.json";
+  const jsonFilename = args[3] || "extension.json";
   let ignoreList: string[];
   // load the list of ignored files
   try {
@@ -32,7 +33,12 @@ if (process.argv.length >= 3) {
   }
   main(corePath, extensionPath, jsonFilename, ignoreList);
 } else {
-  console.log("I need a parameter with the path to the extension");
+  console.log(`I need a parameter with the path to the extension.
+Usage:
+* {string} extensionPath to extension or skin repository
+* {string} [jsonFilename] of repo e.g. extension.json or skin.json
+e.g. resource_modules /srv/mediawiki/skins/MySkin skin.json
+`);
   process.exit(1);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,16 +15,17 @@ const RESOURCES = "/resources";
 const frontendAssets = RESOURCES;
 const coreResources = `${RESOURCES}/Resources.php`;
 
-if (process.argv.length === 3) {
+if (process.argv.length >= 3) {
   const extensionPath = path.resolve(process.argv[2]);
   const corePath = path.resolve(path.join(extensionPath, "../.."));
-  main(corePath, extensionPath);
+  const jsonFilename = process.argv[3] || "extension.json";
+  main(corePath, extensionPath, jsonFilename);
 } else {
   console.log("I need a parameter with the path to the extension");
   process.exit(1);
 }
 
-function main(coreDir: string, dir: string): void {
+function main(coreDir: string, dir: string, json: string): void {
   Promise.all([
     // Get frontend assets
     analyzeJSFiles(dir, frontendAssets, true),
@@ -34,7 +35,7 @@ function main(coreDir: string, dir: string): void {
 
     // Get all ResourceModules definitions
     Promise.all([
-      getJSON(dir, "extension.json").then(
+      getJSON(dir, json).then(
         json => (<ExtensionJson>json).ResourceModules
       ),
       getPhpConfig(coreDir, coreResources)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,9 +51,7 @@ function main(
 
     // Get all ResourceModules definitions
     Promise.all([
-      getJSON(dir, json).then(
-        json => (<ExtensionJson>json).ResourceModules
-      ),
+      getJSON(dir, json).then(json => (<ExtensionJson>json).ResourceModules),
       getPhpConfig(coreDir, coreResources)
     ]).then(
       ([ext, core]: [ResourceModules, ResourceModules]): ResourceModules =>
@@ -91,8 +89,9 @@ function analyzeJSFiles(
   return (
     getJSFiles(dir, resources)
       // Analyze the JS files
-      .then((jsFiles: string[]): Promise<Analysis> =>
-        analyzeFiles(dir, jsFiles, visitors, printAnalysisErrors)
+      .then(
+        (jsFiles: string[]): Promise<Analysis> =>
+          analyzeFiles(dir, jsFiles, visitors, printAnalysisErrors)
       )
   );
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,8 +3,12 @@ import { Errors, FileErrors, MissingMessage } from "../lint/types";
 type FileAndErrors = [string, FileErrors];
 
 // Returns success or error code as an int if it has logged errors out
-export default function logErrors(errors: Errors): number {
+export default function logErrors(
+  allErrors: Errors,
+  ignoreFiles: string[]
+): number {
   let exit = 0;
+  const errors = filterFiles(allErrors, ignoreFiles);
 
   logWarnings(errors);
 
@@ -20,6 +24,19 @@ export default function logErrors(errors: Errors): number {
   });
 
   return exit;
+}
+
+function filterFiles(errors: Errors, ignoreFiles: string[]) {
+  return Object.assign({}, errors, {
+    files: Object.keys(errors.files)
+      // Reduce all files to files not in the ignoreFiles list
+      .filter(filename => ignoreFiles.indexOf(filename) === -1)
+      // and reduce them
+      .reduce(
+        (res, key) => Object.assign(res, { [key]: errors.files[key] }),
+        {}
+      )
+  });
 }
 
 function logWarnings(errors: Errors): void {

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -9,8 +9,9 @@ export function getJSFiles(
   return (
     getFiles(path.join(dir, assetsFolder))
       // Remove folder prefix and filter only JS files
-      .then((files: string[]): string[] =>
-        files.map(replace(dir + path.sep, "")).filter(isValidJSFile)
+      .then(
+        (files: string[]): string[] =>
+          files.map(replace(dir + path.sep, "")).filter(isValidJSFile)
       )
   );
 }
@@ -47,9 +48,11 @@ export function getSources(dir: string, files: string[]): Promise<Sources> {
   let mfiles: Sources = {};
   return Promise.all(
     files.map(f =>
-      getSource(dir, f).then((source: string): void => {
-        mfiles[f] = { source };
-      })
+      getSource(dir, f).then(
+        (source: string): void => {
+          mfiles[f] = { source };
+        }
+      )
     )
   ).then(() => mfiles);
 }

--- a/src/lint/dependencies.ts
+++ b/src/lint/dependencies.ts
@@ -43,26 +43,28 @@ export default function getDependenciesErrors(
 
           // Traverse dependencies of the RLModules where source file is used
           // and check file that defines is there somewhere
-          inModules.forEach(([name, module]: Module): void => {
-            // Script defined before me, or check my dependencies for it
-            const inDependencies: string[] = getDependenciesWithFile(
-              definer,
-              name,
-              module,
-              resourceModules
-            )
-              .filter((v, i, arr) => arr.indexOf(v) === i)
-              .sort();
-            if (inDependencies.length > 1) {
-              errs.push({
-                kind: "file_in_multiple_dependencies",
-                id: mfId,
-                where: [definer, inDependencies]
-              });
-            } else if (inDependencies.length === 0) {
-              errs.push({ kind: "not_found", id: mfId, where: definer });
+          inModules.forEach(
+            ([name, module]: Module): void => {
+              // Script defined before me, or check my dependencies for it
+              const inDependencies: string[] = getDependenciesWithFile(
+                definer,
+                name,
+                module,
+                resourceModules
+              )
+                .filter((v, i, arr) => arr.indexOf(v) === i)
+                .sort();
+              if (inDependencies.length > 1) {
+                errs.push({
+                  kind: "file_in_multiple_dependencies",
+                  id: mfId,
+                  where: [definer, inDependencies]
+                });
+              } else if (inDependencies.length === 0) {
+                errs.push({ kind: "not_found", id: mfId, where: definer });
+              }
             }
-          });
+          );
         }
 
         return errs;

--- a/src/lint/global-dependencies.ts
+++ b/src/lint/global-dependencies.ts
@@ -46,10 +46,12 @@ export default function getGlobalDependenciesErrors(
               analysis.files
             )
               // Get name and analysis paired
-              .map((fileName: string): FileAndAnalysis => [
-                fileName,
-                analysis.files[fileName]
-              ]);
+              .map(
+                (fileName: string): FileAndAnalysis => [
+                  fileName,
+                  analysis.files[fileName]
+                ]
+              );
 
             // Find out which file defines as ns
             const whoDefinesAsNamespace: FileAndAnalysis[] = fileAndAnalysis.filter(
@@ -182,36 +184,38 @@ function checkDefinerFile(
 
   // Only if it is NOT one of the included by default in mediawiki
   if (!isDefaultMediawikiFile(definer)) {
-    inModules.forEach(([name, module]: Module): void => {
-      // Script defined before me, or check my dependencies for it
-      const inDependencies: string[] = getDependenciesWithFile(
-        definer,
-        name,
-        module,
-        resourceModules
-      )
-        // Unique
-        .filter((v, i, arr) => arr.indexOf(v) === i);
-      if (inDependencies.length > 1) {
-        pushUniq(
-          {
-            kind: "file_in_multiple_dependencies",
-            id: globalId,
-            where: [definer, inDependencies.sort()]
-          },
-          errs
-        );
-      } else if (inDependencies.length === 0) {
-        pushUniq(
-          {
-            kind: "not_found",
-            id: globalId,
-            where: definer
-          },
-          errs
-        );
+    inModules.forEach(
+      ([name, module]: Module): void => {
+        // Script defined before me, or check my dependencies for it
+        const inDependencies: string[] = getDependenciesWithFile(
+          definer,
+          name,
+          module,
+          resourceModules
+        )
+          // Unique
+          .filter((v, i, arr) => arr.indexOf(v) === i);
+        if (inDependencies.length > 1) {
+          pushUniq(
+            {
+              kind: "file_in_multiple_dependencies",
+              id: globalId,
+              where: [definer, inDependencies.sort()]
+            },
+            errs
+          );
+        } else if (inDependencies.length === 0) {
+          pushUniq(
+            {
+              kind: "not_found",
+              id: globalId,
+              where: definer
+            },
+            errs
+          );
+        }
       }
-    });
+    );
   }
 }
 

--- a/src/lint/helpers.ts
+++ b/src/lint/helpers.ts
@@ -15,16 +15,18 @@ export function getDependenciesWithFile(
 
   if (module.dependencies) {
     if (Array.isArray(module.dependencies)) {
-      module.dependencies.forEach((dep: string): void => {
-        found = found.concat(
-          getDependenciesWithFile(
-            scriptToFind,
-            dep,
-            resourceModules[dep],
-            resourceModules
-          )
-        );
-      });
+      module.dependencies.forEach(
+        (dep: string): void => {
+          found = found.concat(
+            getDependenciesWithFile(
+              scriptToFind,
+              dep,
+              resourceModules[dep],
+              resourceModules
+            )
+          );
+        }
+      );
     } else if (typeof module.dependencies === "string") {
       found = found.concat(
         getDependenciesWithFile(
@@ -67,11 +69,13 @@ export function getDependenciesWithMessage(
 
   if (module.dependencies) {
     if (Array.isArray(module.dependencies)) {
-      module.dependencies.forEach((dep: string): void => {
-        found = found.concat(
-          getDependenciesWithMessage(msgToFind, dep, resourceModules)
-        );
-      });
+      module.dependencies.forEach(
+        (dep: string): void => {
+          found = found.concat(
+            getDependenciesWithMessage(msgToFind, dep, resourceModules)
+          );
+        }
+      );
     } else if (typeof module.dependencies === "string") {
       found = found.concat(
         getDependenciesWithMessage(

--- a/src/lint/missing-templates.ts
+++ b/src/lint/missing-templates.ts
@@ -14,24 +14,26 @@ export default function getMissingTemplatesErrors(
     return ana.templates.reduce(
       (errs: MissingTemplate[], template: Template): MissingTemplate[] => {
         // Modules with missing templates
-        const missing = inModules.filter(([name, module]: Module): boolean => {
-          if (template.module === name) {
-            if (!module.templates) return true;
-            if (module.templates.constructor === Object) {
-              return !Object.keys(module.templates).some(
-                tplName => tplName === template.fileName
+        const missing = inModules.filter(
+          ([name, module]: Module): boolean => {
+            if (template.module === name) {
+              if (!module.templates) return true;
+              if (module.templates.constructor === Object) {
+                return !Object.keys(module.templates).some(
+                  tplName => tplName === template.fileName
+                );
+              }
+              throw new Error(`In module ${name}, templates is not an object`);
+            } else {
+              const submoduleTemplates =
+                resourceModules[template.module] &&
+                resourceModules[template.module].templates;
+              return !(
+                submoduleTemplates && submoduleTemplates[<any>template.fileName]
               );
             }
-            throw new Error(`In module ${name}, templates is not an object`);
-          } else {
-            const submoduleTemplates =
-              resourceModules[template.module] &&
-              resourceModules[template.module].templates;
-            return !(
-              submoduleTemplates && submoduleTemplates[<any>template.fileName]
-            );
           }
-        });
+        );
         if (missing.length > 0) {
           errs.push({
             kind: "template_not_in_modules",

--- a/src/visitors/index.ts
+++ b/src/visitors/index.ts
@@ -27,11 +27,13 @@ interface ByKey {
 function combineVisitors(visitors: VisitorMap<State>[]): VisitorMap<State> {
   let byKey: ByKey = visitors.reduce(
     (a: ByKey, obj: VisitorMap<State>): ByKey => {
-      Object.keys(obj).forEach((nodeType: string): void => {
-        const visitor: Visitor<State> = obj[nodeType];
-        a[nodeType] = a[nodeType] || [];
-        a[nodeType].push(visitor);
-      });
+      Object.keys(obj).forEach(
+        (nodeType: string): void => {
+          const visitor: Visitor<State> = obj[nodeType];
+          a[nodeType] = a[nodeType] || [];
+          a[nodeType].push(visitor);
+        }
+      );
       return a;
     },
     {}


### PR DESCRIPTION
This adds support for a .resource-modules-ignore file that will give us more control over what errors we care about inside our extensions.

Immediate use will be to disable error reporting for the file resources/dist/mobile.startup.js which will help with migration of webpack (this file does not need resource-modules protection as it makes use of import/exports making the tooling obsolete).

I think it's important to keep resource-modules running on MobileFrontend until the webpack migration is complete.

There are some additional patches here to prettify the code and to allow it to run on skin.json if the JS code in MobileFrontend is ever moved to Minerva. I can separate these from the patch if it makes it easier to review.

See also: https://gerrit.wikimedia.org/r/#/c/mediawiki/extensions/MobileFrontend/+/463861 Resource modules show ignore webpack bundled file 
